### PR TITLE
Expose prometheus metrics endpoint to report e2e latency and gas usage

### DIFF
--- a/app/api/metrics/provider.ts
+++ b/app/api/metrics/provider.ts
@@ -25,8 +25,6 @@ class CachingJsonRpcProvider extends ethers.JsonRpcProvider {
     this.cache.setKey(cacheKey, data);
     this.cache.save(true);
 
-    console.log(`Fetched and cached data for key: ${cacheKey}`);
-
     return data;
   }
 

--- a/app/api/metrics/route.ts
+++ b/app/api/metrics/route.ts
@@ -47,7 +47,9 @@ const createLogPairs = (ackLogs: Array<ethers.EventLog>, sendPacketLogs: Array<e
 
     if (ackLogsMap.has(key)) {
       const ackLog = ackLogsMap.get(key)!;
-      logPairs.push({ackLog, sendPacketLog});
+      if (ackLog.blockNumber > sendPacketLog.blockNumber) {
+        logPairs.push({ackLog, sendPacketLog});
+      }
     }
   });
 

--- a/app/chains.ts
+++ b/app/chains.ts
@@ -12,7 +12,7 @@ export const CHAIN_CONFIGS: {
   optimism: {
     id: 11155420,
     display: "Optimism",
-    rpc: "https://opt-sepolia.g.alchemy.com/v2/RN7slh_2cUIuzhxo4M9VgYCbqRcPOmkJ",
+    rpc: "https://opt-sepolia.g.alchemy.com/v2/jKvLhhXvtnWdNeZrKst0demxnwJcYH1o",
     dispatcher: opDispatcher,
     blockTime: 2,
     icon: OptimismIcon,
@@ -20,7 +20,7 @@ export const CHAIN_CONFIGS: {
   base: {
     id: 84532,
     display: "Base",
-    rpc: "https://base-sepolia.g.alchemy.com/v2/zGVxj0T-xvSR29_t7MlIhqRskkSwugVM",
+    rpc: "https://base-sepolia.g.alchemy.com/v2/776dC6qT-NTtupdnxlUJuXGbUIKWWhLe",
     dispatcher: baseDispatcher,
     blockTime: 2,
     icon: BaseIcon,

--- a/app/metrics/route.ts
+++ b/app/metrics/route.ts
@@ -11,8 +11,13 @@ export async function GET(request: NextRequest) {
   const oneHourAgo = new Date();
   oneHourAgo.setHours(now.getHours() - 1);
 
-
-  const metrics = await calcMetrics([oneHourAgo, now], request.nextUrl.origin);
+  let metrics;
+  try {
+    metrics = await calcMetrics([oneHourAgo, now], request.nextUrl.origin);
+  } catch (error) {
+    console.error('Failed to calculate metrics:', error);
+    return new Response('Internal Server Error', { status: 500 });
+  }
   for (let chainMetrics of metrics) {
     for (let metric of chainMetrics) {
       if (metric.stat == 0) {

--- a/app/metrics/route.ts
+++ b/app/metrics/route.ts
@@ -40,7 +40,6 @@ export async function GET(request: NextRequest) {
 
   return new Response(defaultMetrics, {
     headers: {
-      'Cache-Control': 'no-store',
       'Content-type': register.contentType
     }
   });

--- a/app/metrics/route.ts
+++ b/app/metrics/route.ts
@@ -1,0 +1,43 @@
+import { register, Gauge } from 'prom-client';
+import { calcMetrics } from '../utils';
+import { NextRequest } from 'next/server';
+
+export const dynamic = 'force-dynamic'; // defaults to auto
+
+let gauges: { [key: string]: Gauge } = {};
+
+export async function GET(request: NextRequest) {
+  const now = new Date();
+  const oneHourAgo = new Date();
+  oneHourAgo.setHours(now.getHours() - 1);
+
+
+  const metrics = await calcMetrics([oneHourAgo, now], request.nextUrl.origin);
+  for (let chainMetrics of metrics) {
+    for (let metric of chainMetrics) {
+      if (metric.stat == 0) {
+        continue
+      }
+
+      for (let stat of metric.data) {
+        let gauge = gauges[metric.key] ?? new Gauge({
+          name: metric.key,
+          help: metric.category,
+          labelNames: ['chainName', 'statName']
+        });
+        gauge.labels(metric.chain, stat.name).set(stat.value);
+        gauges[metric.key] = gauge
+      }
+    }
+  }
+
+  let defaultMetrics = await register.metrics();
+
+  return new Response(defaultMetrics, {
+    headers: {
+      'Cache-Control': 'no-store',
+      'Content-type': register.contentType
+    }
+  });
+
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,32 +2,12 @@
 
 import React, { useEffect, useState } from 'react';
 import { BarList, Card, Divider, Flex, Grid, Metric, Text, Title } from '@tremor/react';
-import * as stats from 'stats-lite';
-import { CHAIN, CHAIN_CONFIGS, getLatestBlock } from "./chains";
-import DateTimeRangePicker from "./components/DateTimePicker";
-import { Block } from "ethers";
-import _ from "lodash";
-import { Spinner } from "@nextui-org/react";
-import { EvmData } from "./api/metrics/route";
-import { IdentifiedChannel } from "cosmjs-types/ibc/core/channel/v1/channel";
-
-const calculateStats = (latencies: number[]): {
-  avg: number;
-  min: number;
-  median: number;
-  max: number;
-} => {
-  const avg = stats.mean(latencies);
-  const min = Math.min(...latencies);
-  const median = stats.median(latencies);
-  const max = Math.max(...latencies);
-
-  return {avg, min, median, max};
-};
-
-const calculateBlockNumber = (timestamp: number, latestBlock: Block, blockTime: number) => {
-  return Math.ceil(latestBlock.number - (latestBlock.timestamp - timestamp) / blockTime);
-};
+import { CHAIN_CONFIGS } from './chains';
+import DateTimeRangePicker from './components/DateTimePicker';
+import _ from 'lodash';
+import { Spinner } from '@nextui-org/react';
+import { IdentifiedChannel } from 'cosmjs-types/ibc/core/channel/v1/channel';
+import { calcMetrics } from './utils';
 
 interface MetricData {
   category: string;
@@ -52,52 +32,15 @@ const MetricsPage: React.FC = () => {
     fetch(`/api/ibc/channels`).then(res => res.json()).then(data => {
       let ports = new Set<string>();
       data.map((item: IdentifiedChannel) => {
-        ports.add(item.portId)
-        ports.add(item.counterparty.portId)
-      })
-      setDapps(ports.size)
-    })
-  }, [dateRange])
+        ports.add(item.portId);
+        ports.add(item.counterparty.portId);
+      });
+      setDapps(ports.size);
+    });
+  }, [dateRange]);
 
   const fetchData = async () => {
-    Promise.all(Object.keys(CHAIN_CONFIGS).map(async (chain) => {
-      const blockTime = CHAIN_CONFIGS[chain as CHAIN].blockTime;
-      const latestBlock = await getLatestBlock(chain as CHAIN);
-
-      const blockStartNumber = calculateBlockNumber(dateRange[0].getTime() / 1000, latestBlock!, blockTime);
-      const blockEndNumber = calculateBlockNumber(dateRange[1].getTime() / 1000, latestBlock!, blockTime);
-
-      console.log(`Block Number for ${chain} for Start Date: ${blockStartNumber}`);
-      console.log(`Block Number for ${chain} End Date ${blockEndNumber}`);
-
-
-      const response = await fetch(`/api/metrics?from=${blockStartNumber}&to=${blockEndNumber}&chain=${chain}`);
-      const evmData: EvmData[] = await response.json()
-
-      const statsTemplate = {
-        txLatency: `${_.capitalize(chain)} E2E Tx Latency in seconds`,
-        ackTransactionCost: `${_.capitalize(chain)} Ack Gas Cost in gwei`,
-        sendPacketTransactionCost: `${_.capitalize(chain)} Send Packet Gas Cost in gwei`,
-      }
-
-      return Object.keys(statsTemplate).map((key) => {
-        const title = statsTemplate[key as keyof typeof statsTemplate];
-        const data = _.map(evmData, key);
-
-        const stats = calculateStats(data);
-
-        return {
-          category: title,
-          stat: data.length,
-          data: [
-            {name: "Avg", value: stats.avg},
-            {name: "Min", value: stats.min},
-            {name: "Median", value: stats.median},
-            {name: "Max", value: stats.max},
-          ],
-        };
-      });
-    })).then((data) => {
+    calcMetrics(dateRange).then((data) => {
       setIsLoading(false);
       setData(_.flatten(data));
     });
@@ -109,55 +52,55 @@ const MetricsPage: React.FC = () => {
   }, [dateRange]);
 
   const handleRangeChange = async (newStartDate: Date, newEndDate: Date) => {
-    setDateRange([newStartDate, newEndDate])
+    setDateRange([newStartDate, newEndDate]);
   };
 
   return (
-    <main className="p-4 md:p-10 mx-auto max-w-7xl">
+    <main className='p-4 md:p-10 mx-auto max-w-7xl'>
       <Divider>Filter</Divider>
-      <DateTimeRangePicker onRangeChange={handleRangeChange} initialStartDate={startOfDay} initialEndDate={now}/>
-      {isLoading && <Spinner label="Loading..."/>}
+      <DateTimeRangePicker onRangeChange={handleRangeChange} initialStartDate={startOfDay} initialEndDate={now} />
+      {isLoading && <Spinner label='Loading...' />}
       {!isLoading &&
-          <>
-              <Divider>KPI</Divider>
-              <Grid numItemsSm={2} numItemsLg={3} className="gap-6">
-                  <Card className="" decoration="top" decorationColor="slate">
-                      <Text>Connected chains</Text>
-                      <Metric>{Object.keys(CHAIN_CONFIGS).length}</Metric>
-                  </Card>
-                  <Card className="" decoration="top" decorationColor="slate">
-                      <Text>Number of DApps</Text>
-                      <Metric>{dapps}</Metric>
-                  </Card>
-              </Grid>
-              <Divider>Sepolia</Divider>
-              <Grid numItemsSm={2} numItemsLg={3} className="gap-6">
-                {data.map((item) => (
-                  <Card key={item.category}>
-                    <Title>{item.category}</Title>
-                    <Flex
-                      justifyContent="start"
-                      alignItems="baseline"
-                      className="space-x-2"
-                    >
-                      <Metric>{item.stat}</Metric>
-                      <Text>Total packets </Text>
-                    </Flex>
-                    <Flex className="mt-6">
-                      <Text>Statistics</Text>
-                      <Text className="text-right">Value</Text>
-                    </Flex>
-                    <BarList
-                      data={item.data}
-                      valueFormatter={(number: number) =>
-                        Intl.NumberFormat('us').format(number).toString()
-                      }
-                      className="mt-2"
-                    />
-                  </Card>
-                ))}
-              </Grid>
-          </>
+        <>
+          <Divider>KPI</Divider>
+          <Grid numItemsSm={2} numItemsLg={3} className='gap-6'>
+            <Card className='' decoration='top' decorationColor='slate'>
+              <Text>Connected chains</Text>
+              <Metric>{Object.keys(CHAIN_CONFIGS).length}</Metric>
+            </Card>
+            <Card className='' decoration='top' decorationColor='slate'>
+              <Text>Number of DApps</Text>
+              <Metric>{dapps}</Metric>
+            </Card>
+          </Grid>
+          <Divider>Sepolia</Divider>
+          <Grid numItemsSm={2} numItemsLg={3} className='gap-6'>
+            {data.map((item) => (
+              <Card key={item.category}>
+                <Title>{item.category}</Title>
+                <Flex
+                  justifyContent='start'
+                  alignItems='baseline'
+                  className='space-x-2'
+                >
+                  <Metric>{item.stat}</Metric>
+                  <Text>Total packets </Text>
+                </Flex>
+                <Flex className='mt-6'>
+                  <Text>Statistics</Text>
+                  <Text className='text-right'>Value</Text>
+                </Flex>
+                <BarList
+                  data={item.data}
+                  valueFormatter={(number: number) =>
+                    Intl.NumberFormat('us').format(number).toString()
+                  }
+                  className='mt-2'
+                />
+              </Card>
+            ))}
+          </Grid>
+        </>
       }
     </main>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -41,9 +41,10 @@ const MetricsPage: React.FC = () => {
 
   const fetchData = async () => {
     calcMetrics(dateRange).then((data) => {
-      setIsLoading(false);
       setData(_.flatten(data));
-    });
+    }).catch((e) => {
+      console.error('Failed to fetch metrics data:', e);
+    }).finally(() => setIsLoading(false));
   };
 
   useEffect(() => {

--- a/app/utils.ts
+++ b/app/utils.ts
@@ -37,7 +37,7 @@ export async function calcMetrics(dateRange: [Date, Date], origin: string= '') {
       response = await fetch(`${origin}/api/metrics?from=${blockStartNumber}&to=${blockEndNumber}&chain=${chain}`);
     } catch (error) {
       console.error(`Failed to fetch metrics for chain ${chain}:`, error);
-      continue; // Skip this chain's metrics calculation on error
+      return []; // Skip this chain's metrics calculation on error
     }
     const evmData: EvmData[] = await response.json();
 

--- a/app/utils.ts
+++ b/app/utils.ts
@@ -32,8 +32,13 @@ export async function calcMetrics(dateRange: [Date, Date], origin: string= '') {
     console.log(`Block Number for ${chain} for Start Date: ${blockStartNumber}`);
     console.log(`Block Number for ${chain} End Date ${blockEndNumber}`);
 
-
-    const response = await fetch(`${origin}/api/metrics?from=${blockStartNumber}&to=${blockEndNumber}&chain=${chain}`);
+    let response;
+    try {
+      response = await fetch(`${origin}/api/metrics?from=${blockStartNumber}&to=${blockEndNumber}&chain=${chain}`);
+    } catch (error) {
+      console.error(`Failed to fetch metrics for chain ${chain}:`, error);
+      continue; // Skip this chain's metrics calculation on error
+    }
     const evmData: EvmData[] = await response.json();
 
     const statsTemplate = {

--- a/app/utils.ts
+++ b/app/utils.ts
@@ -1,0 +1,65 @@
+import { Block } from 'ethers';
+import * as stats from 'stats-lite';
+import { CHAIN, CHAIN_CONFIGS, getLatestBlock } from './chains';
+import { EvmData } from './api/metrics/route';
+import _ from 'lodash';
+
+export const calculateBlockNumber = (timestamp: number, latestBlock: Block, blockTime: number) => {
+  return Math.ceil(latestBlock.number - (latestBlock.timestamp - timestamp) / blockTime);
+};
+export const calculateStats = (latencies: number[]): {
+  avg: number;
+  min: number;
+  median: number;
+  max: number;
+} => {
+  const avg = stats.mean(latencies);
+  const min = Math.min(...latencies);
+  const median = stats.median(latencies);
+  const max = Math.max(...latencies);
+
+  return { avg, min, median, max };
+};
+
+export async function calcMetrics(dateRange: [Date, Date], origin: string= '') {
+  return await Promise.all(Object.keys(CHAIN_CONFIGS).map(async (chain) => {
+    const blockTime = CHAIN_CONFIGS[chain as CHAIN].blockTime;
+    const latestBlock = await getLatestBlock(chain as CHAIN);
+
+    const blockStartNumber = calculateBlockNumber(dateRange[0].getTime() / 1000, latestBlock!, blockTime);
+    const blockEndNumber = calculateBlockNumber(dateRange[1].getTime() / 1000, latestBlock!, blockTime);
+
+    console.log(`Block Number for ${chain} for Start Date: ${blockStartNumber}`);
+    console.log(`Block Number for ${chain} End Date ${blockEndNumber}`);
+
+
+    const response = await fetch(`${origin}/api/metrics?from=${blockStartNumber}&to=${blockEndNumber}&chain=${chain}`);
+    const evmData: EvmData[] = await response.json();
+
+    const statsTemplate = {
+      txLatency: `${_.capitalize(chain)} E2E Tx Latency in seconds`,
+      ackTransactionCost: `${_.capitalize(chain)} Ack Gas Cost in gwei`,
+      sendPacketTransactionCost: `${_.capitalize(chain)} Send Packet Gas Cost in gwei`
+    };
+
+    return Object.keys(statsTemplate).map((key) => {
+      const title = statsTemplate[key as keyof typeof statsTemplate];
+      const data = _.map(evmData, key);
+
+      const stats = calculateStats(data);
+
+      return {
+        key: key,
+        category: title,
+        chain: chain,
+        stat: data.length,
+        data: [
+          { name: 'Avg', value: stats.avg },
+          { name: 'Min', value: stats.min },
+          { name: 'Median', value: stats.median },
+          { name: 'Max', value: stats.max }
+        ]
+      };
+    });
+  }));
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "next": "14.0.0",
         "postcss": "^8.4.31",
         "prettier": "^3.0.3",
+        "prom-client": "^15.1.0",
         "prop-types": "^15.8.1",
         "react": "18.2.0",
         "react-dom": "18.2.0",
@@ -2127,6 +2128,14 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.7.0.tgz",
+      "integrity": "sha512-AdY5wvN0P2vXBi3b29hxZgSFvdhdxPB9+f0B6s//P9Q8nibRWeA3cHm8UmLpio9ABigkVHJ5NMPk+Mz8VCCyrw==",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -4204,6 +4213,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/bintrees": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
+      "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw=="
     },
     "node_modules/bn.js": {
       "version": "5.2.1",
@@ -7323,6 +7337,18 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/prom-client": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-15.1.0.tgz",
+      "integrity": "sha512-cCD7jLTqyPdjEPBo/Xk4Iu8jxjuZgZJ3e/oET3L+ZwOuap/7Cw3dH/TJSsZKs1TQLZ2IHpIlRAKw82ef06kmMw==",
+      "dependencies": {
+        "@opentelemetry/api": "^1.4.0",
+        "tdigest": "^0.1.1"
+      },
+      "engines": {
+        "node": "^16 || ^18 || >=20"
+      }
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -8304,6 +8330,14 @@
       "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/tdigest": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz",
+      "integrity": "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==",
+      "dependencies": {
+        "bintrees": "1.0.2"
       }
     },
     "node_modules/telejson": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "next": "14.0.0",
     "postcss": "^8.4.31",
     "prettier": "^3.0.3",
+    "prom-client": "^15.1.0",
     "prop-types": "^15.8.1",
     "react": "18.2.0",
     "react-dom": "18.2.0",


### PR DESCRIPTION
Example of reported metrics at `/metrics`:
```
# HELP txLatency Optimism E2E Tx Latency in seconds
# TYPE txLatency gauge
txLatency{chainName="optimism",statName="Avg"} 26
txLatency{chainName="optimism",statName="Min"} 26
txLatency{chainName="optimism",statName="Median"} 26
txLatency{chainName="optimism",statName="Max"} 26

# HELP ackTransactionCost Optimism Ack Gas Cost in gwei
# TYPE ackTransactionCost gauge
ackTransactionCost{chainName="optimism",statName="Avg"} 219.222230084
ackTransactionCost{chainName="optimism",statName="Min"} 219.222230084
ackTransactionCost{chainName="optimism",statName="Median"} 219.222230084
ackTransactionCost{chainName="optimism",statName="Max"} 219.222230084

# HELP sendPacketTransactionCost Optimism Send Packet Gas Cost in gwei
# TYPE sendPacketTransactionCost gauge
sendPacketTransactionCost{chainName="optimism",statName="Avg"} 91.937162328
sendPacketTransactionCost{chainName="optimism",statName="Min"} 91.937162328
sendPacketTransactionCost{chainName="optimism",statName="Median"} 91.937162328
sendPacketTransactionCost{chainName="optimism",statName="Max"} 91.937162328
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced a new metrics route for Prometheus metrics.
	- Updated `CHAIN_CONFIGS` with new RPC URLs for "Optimism" and "Base" chains.
	- Added utility functions for blockchain data analysis and metrics calculation.

- **Bug Fixes**
	- Improved packet sequencing in the `getPackets` function by adding timestamp checks.
	- Added a condition to ensure `ackLog`'s `blockNumber` is greater than `sendPacketLog`'s before processing.

- **Refactor**
	- Removed unnecessary logging in `CachingJsonRpcProvider`.
	- Reorganized and refactored code related to metrics calculation and data fetching in `app/page.tsx`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->