### PR TITLE
Use unified contracts addresses

### DIFF
--- a/app/chains.ts
+++ b/app/chains.ts
@@ -3,8 +3,8 @@ import { Chain } from "./types/chain";
 import { OptimismIcon, BaseIcon } from "./icons/Chains";
 
 export type CHAIN = 'optimism' | 'base';
-let opDispatcher = process.env.OP_DISPATCHER!;
-let baseDispatcher = process.env.BASE_DISPATCHER!;
+let opDispatcher = process.env.DISPATCHER_ADDRESS_OPTIMISM!;
+let baseDispatcher = process.env.DISPATCHER_ADDRESS_BASE!;
 
 export const CHAIN_CONFIGS: {
   [key in CHAIN]: Chain;


### PR DESCRIPTION
Issue: https://github.com/polymerdao/infra/issues/30

To be able to share the contract addresses between various k8s components, the env var names needs be the same.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated dispatcher addresses for 'optimism' and 'base' chains to enhance connectivity and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->