### PR TITLE
fix header row height

### DIFF
--- a/app/components/ibc-table.tsx
+++ b/app/components/ibc-table.tsx
@@ -124,7 +124,7 @@ export function IbcTable<TableType extends Packet | Client | IdentifiedChannel |
                       header.id === 'destChain'
                       ? "pl-4"
                       : "pl-8"
-                      , "pb-2 dark:bg-bg-dark last:pr-6 whitespace-nowrap"
+                      , "pb-2 h-20 dark:bg-bg-dark last:pr-6 whitespace-nowrap"
                     )}
                     style={{width: header.getSize()}}>
                     {header.isPlaceholder ? null : (


### PR DESCRIPTION
Fix #68  the height of the header row of the table, `height` (`h-20`) is not working for `<thead>` in Safari.

Applying the height setting to `<th>` instead.