### PR TITLE
Channels modal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,9 @@ yarn-error.log*
 # local env files
 .env*.local
 
+# local logs
+*.log
+
 # vercel
 .vercel
 

--- a/app/(routes)/channels/channel-details.tsx
+++ b/app/(routes)/channels/channel-details.tsx
@@ -1,0 +1,61 @@
+import { useEffect } from 'react';
+import { IdentifiedChannel, stateToString } from 'utils/types/channel';
+
+export function ChannelDetails(channel: IdentifiedChannel | null) {
+  useEffect(() => {
+    if (channel) {
+      // Update URL with channelId
+      window.history.pushState({}, '', `/channels/?channelId=${channel.channelId}`);
+    }
+  }, [channel]);
+
+  return !channel ? (
+    <>
+      <h2 className="mt-1 mb-2 mr-8">No Results</h2>
+      <p>Channel not found</p>
+    </>
+  ) : (
+    <div className="pl-8 pr-6 pt-2 pb-5 min-w-[870px]">
+      <h1>Channel Details</h1>
+      <div className="flex flex-col gap-2 mt-7">
+        <div className="flex flex-row justify-between">
+          <p className="mr-8 font-semibold">Channel ID</p>
+          <p className="font-mono text-[17px]/[24px]">{ channel.channelId }</p>
+        </div>
+        <Divider />
+        <div className="flex flex-row justify-between">
+          <p className="mr-8 font-semibold">State</p>
+          <p className="font-mono text-[17px]/[24px]">{ stateToString(channel.state) }</p>
+        </div>
+        <Divider />
+        <div className="flex flex-row justify-between">
+          <p className="mr-8 font-semibold">Counterparty Channel ID</p>
+          <p className="font-mono text-[17px]/[24px]">{ channel.counterparty.channelId }</p>
+        </div>
+        <Divider />
+        <div className="flex flex-row justify-between">
+          <p className="mr-8 font-semibold">Port ID</p>
+          <p className="font-mono text-[17px]/[24px]">{ channel.portId }</p>
+        </div>
+        <Divider />
+        <div className="flex flex-row justify-between">
+          <p className="mr-8 font-semibold">Counterparty Port ID</p>
+          <p className="font-mono text-[17px]/[24px]">{ channel.counterparty.portId }</p>
+        </div>
+        <Divider />
+        <div className="flex flex-row justify-between">
+          <p className="mr-8 font-semibold">Connection Hops</p>
+          <p className="font-mono text-[17px]/[24px]">{ channel.connectionHops[0] }, { channel.connectionHops[1] }</p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Divider () {
+  return (
+    <div className="flex flex-row justify-center my-0.5">
+      <div className="h-0 mb-[0.5px] mt-[1.5px] w-[calc(100%-0.5rem)] border-b border-fg-dark/30"></div>
+    </div>
+  );
+}

--- a/app/(routes)/clients/page.tsx
+++ b/app/(routes)/clients/page.tsx
@@ -48,7 +48,7 @@ const columns = [
 ];
 
 export default function Packets() {
-  const [connections, setConnections] = useState<Client[]>([]);
+  const [clients, setClients] = useState<Client[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(false);
   const [errorMessage, setErrorMessage] = useState('');
@@ -72,7 +72,7 @@ export default function Packets() {
         return res.json();
       })
       .then(data => {
-        setConnections(data);
+        setClients(data);
         setLoading(false);
       }).catch(err => {
         setError(true);
@@ -81,7 +81,7 @@ export default function Packets() {
   }
 
   const table = useReactTable({
-    data: connections,
+    data: clients,
     columns,
     state: {
       columnVisibility

--- a/app/(routes)/packets/packet-details.tsx
+++ b/app/(routes)/packets/packet-details.tsx
@@ -175,7 +175,7 @@ function linkAndCopy(url: string, path: string, hex?: string) {
   }
 
   return (
-    <div className="whitespace-nowrap flex flex-row transition ease-in-out duration-300">
+    <div className="whitespace-nowrap flex flex-row">
       <Link href={url + path + '/' + hex} target="_blank"
         className="text-sky-600 dark:text-sky-400 font-mono text-[17px]/[24px] hover:underline underline-offset-2">
         {hex}

--- a/app/(routes)/packets/page.tsx
+++ b/app/(routes)/packets/page.tsx
@@ -15,8 +15,8 @@ import { IbcTable } from 'components/ibc-table';
 import { Modal } from 'components/modal';
 import { Packet } from 'utils/types/packet';
 import { PacketDetails } from './packet-details';
-import { StateCell } from './state-cell';
 import { stateToString } from 'utils/types/packet';
+import { StateCell } from 'components/state-cell';
 import { ChainCell, Arrow } from 'components/chain-cell';
 import { shortenHex } from 'components/format-strings';
 
@@ -121,7 +121,7 @@ const columns = [
 export default function Packets() {
   const [packets, setPackets] = useState<Packet[]>([]);
   const [searchHash, setSearchHash] = useState<string>('');
-  const [searchPacket, setSearchPacket] = useState(false);
+  const [packetSearch, setPacketSearch] = useState(false);
   const [foundPacket, setFoundPacket] = useState<Packet | null>(null);
   const [loading, setLoading] = useState(true);
   const [searchLoading, setSearchLoading] = useState(false);
@@ -171,13 +171,13 @@ export default function Packets() {
   function searchByHash() {
     setSearchLoading(true);
     setFoundPacket(null);
-    setSearchPacket(true);
+    setPacketSearch(true);
     fetch(`/api/packets?txHash=${searchHash}`, { signal: controller.signal })
       .then(res => {
         if (!res.ok) {
           setErrorMessage(res.statusText);
           setError(true);
-          setSearchPacket(false);
+          setPacketSearch(false);
           setSearchLoading(false);
         }
         return res.json();
@@ -191,7 +191,7 @@ export default function Packets() {
         setSearchLoading(false);
       }).catch(() => {
         setError(true);
-        setSearchPacket(false);
+        setPacketSearch(false);
         setSearchLoading(false);
       });
   }
@@ -235,9 +235,9 @@ export default function Packets() {
       />
 
       <Modal 
-        open={searchPacket} 
+        open={packetSearch} 
         onClose={() => {
-          setSearchPacket(false);
+          setPacketSearch(false);
           if (searchLoading) {
             controller.abort();
             setSearchLoading(false);

--- a/app/api/channels/route.ts
+++ b/app/api/channels/route.ts
@@ -1,21 +1,21 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { getChannel, getChannels } from 'api/channels/helpers';
+import { getChannel, getUniversalChannels } from 'api/channels/helpers';
 import logger from 'utils/logger';
 
 export const dynamic = 'force-dynamic'; // defaults to auto
 
 export async function GET(request: NextRequest) {
-  const searchId = request.nextUrl.searchParams.get('searchId');
-  if (!searchId) {
-    return NextResponse.json(await getChannels())
+  const channelId = request.nextUrl.searchParams.get('channelId');
+
+  if (!channelId) {
+    return NextResponse.json(await getUniversalChannels())
   }
 
   try {
-    const channels = await getChannel(searchId);
-    return NextResponse.json(channels);
+    return NextResponse.json(await getChannel(channelId));
   }
   catch (err) {
-    logger.error(err);
+    logger.error(`Error searching for channel ${channelId}: ${err}`);
     return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });
   }
 }

--- a/app/components/format-strings.tsx
+++ b/app/components/format-strings.tsx
@@ -1,3 +1,4 @@
+import { connect } from 'http2';
 import { CopyButton } from './copy-button';
 
 export function shortenHex(hex: string, copyable?: boolean) {
@@ -10,4 +11,28 @@ export function shortenHex(hex: string, copyable?: boolean) {
       {copyable && <CopyButton str={hex} />}
     </div>
   );
+}
+
+export function formatPortId(portId: string) {
+  if (!portId) return null;
+  const shortened =  portId.slice(0, 18) + '...' + portId.slice(-5);
+
+  return (
+    <div className="flex flex-row text-nowrap">
+      <span title={portId}>{shortened}</span>
+    </div>
+  );
+}
+
+export function formatConnectionHops(connectionHops: string[]) {
+  if (!connectionHops) return null;
+
+  let asString = '';
+  connectionHops.forEach((hop, index) => {
+    asString += hop;
+    if (index < connectionHops.length - 1) {
+      asString += ', ';
+    }
+  });
+  return asString;
 }

--- a/app/components/ibc-table.tsx
+++ b/app/components/ibc-table.tsx
@@ -10,7 +10,7 @@ import { CHAIN_CONFIGS } from 'utils/chains/configs';
 import { Packet } from 'utils/types/packet';
 import { Client } from 'utils/types/client';
 import { IdentifiedConnection } from 'cosmjs-types/ibc/core/connection/v1/connection';
-import { IdentifiedChannel } from 'cosmjs-types/ibc/core/channel/v1/channel';
+import { IdentifiedChannel } from 'utils/types/channel';
 import { classNames, classLogic } from 'utils/functions';
 import { Select } from 'components/select';
 import { OrbitLoader } from 'components/loading/loader';
@@ -32,7 +32,7 @@ export function IbcTable<TableType extends Packet | Client | IdentifiedChannel |
     <div className="relative mt-4">
 
       {/* Table View Options */}
-      <div className="flex flex-row justify-between items-end mb-2 mx-1 text-slate-700 dark:text-slate-300">
+      <div className="flex flex-row justify-between items-end mb-2 ml-1.5 mr-1 text-slate-700 dark:text-slate-300">
         <span>
           Last {table.getFilteredRowModel().rows.length} Results
         </span>
@@ -246,7 +246,7 @@ function ColumnFilter({ column, table }: { column: Column<any, any>, table: Tabl
           ...Object.entries(CHAIN_CONFIGS).map(([key, value]) => ({ value: key, label: value.display }))]
         }
         onChange={value => column.setFilterValue(value)}
-        containerClassName="w-24"
+        containerClassName="w-28"
         buttonClassName="inpt h-8 pl-[9px] cursor-default"
         dropdownClassName="bg-bg-light dark:bg-bg-dark"
       />
@@ -264,13 +264,19 @@ function ColumnFilter({ column, table }: { column: Column<any, any>, table: Tabl
             case 'counterparty_connectionid':
               break;
             case 'state':
-              classes += ' max-w-[9.5rem]';
+              classes += ' max-w-[9rem]';
               break;
             case 'delayperiod':
               classes += ' max-w-32';
               break;
-            case 'counterparty_channelid':
+            case 'channelid':
+              classes += ' max-w-36';
+              break;
+            case 'portid':
               classes += ' max-w-48';
+              break;
+            case 'counterparty_channelid':
+              classes += ' max-w-32';
               break;
             default:
               classes += ' max-w-44';

--- a/app/components/state-cell.tsx
+++ b/app/components/state-cell.tsx
@@ -3,7 +3,7 @@ import { classNames } from 'utils/functions';
 export function StateCell(state: string) {
   return (
     <div className={classNames(
-      state === 'Delivered'
+      state === 'Delivered' || state === 'Open'
       ? 'bg-emerald-500/60'
       : 'bg-sky-500/50'
       , 'flex flex-row w-32 justify-center rounded-xl py-[2.2px]'

--- a/app/utils/types/channel.ts
+++ b/app/utils/types/channel.ts
@@ -1,0 +1,16 @@
+export { IdentifiedChannel, State } from 'cosmjs-types/ibc/core/channel/v1/channel';
+import { State } from 'cosmjs-types/ibc/core/channel/v1/channel';
+
+export function stateToString(state: State): string {
+  switch (state) {
+    case State.STATE_OPEN: return 'Open'
+    case State.STATE_INIT: return 'Initialized'
+    case State.STATE_CLOSED: return 'Closed'
+    case State.STATE_TRYOPEN:
+    case State.UNRECOGNIZED:
+    case State.STATE_UNINITIALIZED_UNSPECIFIED:
+      return 'Pending'
+    default:
+      return 'Pending'
+  }
+}


### PR DESCRIPTION
This is basic functionality to show only UCs by default on the Channels page, make other channels searchable by ID and make it possible to navigate to a specific channel by including it as a url param.

Still needs more functionality in the new modal and styling work, as well as coordination with product to figure out how to show DApp specific data. Merging incrementally so PRs don't get too big.

This will also require new ENV variable:
`REGISTRY_URL='https://raw.githubusercontent.com/polymerdao/polymer-registry/staging/dist/output.json'`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced detailed channel information view, including channel ID, state, port IDs, and connection hops.
  - Added search functionality for channels by ID.
  - Enhanced error handling and modal behavior.
  - Added new columns 'Source' and 'Dest' to display chain information.

- **Improvements**
  - Updated UI elements for channel search.
  - Improved display formatting for port IDs and counterparty port columns.
  - Enhanced state representation with new `stateToString` function.
  - Updated table components to include row details using the new `ChannelDetails` component.

- **Bug Fixes**
  - Improved error logging to include specific channel IDs during errors.
  - Enhanced error handling in search and modal components.

- **Style**
  - Adjusted styling classes for margin in various components.
  - Removed transition effects from packet details for a static display.

- **Refactor**
  - Renamed and refactored variable names for clarity and consistency.
  - Updated import paths for better organization.

- **Chores**
  - Added rule to ignore local log files in the repository.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->