### PR TITLE
Fixed bug not showing recent packets

### DIFF
--- a/app/(routes)/packets/page.tsx
+++ b/app/(routes)/packets/page.tsx
@@ -139,9 +139,9 @@ export default function Packets() {
   const [srcFilter, setSrcFilter] = useState<string>('');
   const [destFilter, setDestFilter] = useState<string>('');
   const [stateFilter, setStateFilter] = useState<Array<state>>([
-    { value: 'SENT', label: 'Relaying', selected: false },
-    { value: 'RECV,WRITE_ACK', label: 'Confirming', selected: false },
-    { value: 'ACK', label: 'Delivered', selected: false }
+    { value: 'SENT', label: 'Relaying', selected: true },
+    { value: 'RECV,WRITE_ACK', label: 'Confirming', selected: true },
+    { value: 'ACK', label: 'Delivered', selected: true }
   ]);
   const [pageNumber, setPageNumber] = useState(1);
   const [foundPacket, setFoundPacket] = useState<Packet | null>(null);

--- a/app/api/packets/route.ts
+++ b/app/api/packets/route.ts
@@ -16,7 +16,7 @@ export async function GET(request: NextRequest) {
   const offset = Number(searchParams.get('offset'));
   let start = searchParams.get('start') || '';
   let end = searchParams.get('end') || '';
-  let states = searchParams.get('states') || '';
+  let states = searchParams.get('states') || 'SENT,RECV,WRITE_ACK,ACK';
   let src = searchParams.get('src') || '';
   let dest = searchParams.get('dest') || '';
 


### PR DESCRIPTION
An empty 'where' part of the query was causing weird behavior not showing the most recent packets. Defaulting to all states when no states are selected prevents this case from occuring and fixes the issue.