### PR TITLE
Displaying amount by which packets are underfunded

### DIFF
--- a/app/api/packets/helpers.ts
+++ b/app/api/packets/helpers.ts
@@ -70,9 +70,13 @@ function processPacketResponse(packetResponse: any[]): Packet[] {
       sendTx: packet.sendPacket?.transactionHash,
       rcvTx: packet.recvPacket?.transactionHash,
       ackTx: packet.ackPacket?.transactionHash,
-      sourceClient: packet.sendPacket?.sourceChannel?.portId.split('.')[1],
-      destClient: packet.sendPacket?.sourceChannel?.counterpartyPortId.split('.')[1],
-      senderAddress: packet.sendPacket?.uchEventSender || packet.sendPacket?.packetDataSender || ''
+      sourceClient: packet.sendPacket?.sourceChannel?.portId.split('.')[1] || '',
+      destClient: packet.sendPacket?.sourceChannel?.counterpartyPortId.split('.')[1] || '',
+      senderAddress: packet.sendPacket?.uchEventSender || packet.sendPacket?.packetDataSender || '',
+      totalRecvFeesDeposited: packet.sendPacket?.totalRecvFeesDeposited || 0,
+      recvGasLimit: packet.sendPacket?.firstFeeDeposited?.recvGasLimit || undefined,
+      totalAckFeesDeposited: packet.sendPacket?.totalAckFeesDeposited || 0,
+      ackGasLimit: packet.sendPacket?.firstFeeDeposited?.ackGasLimit || undefined
     };
     packets.push(newPacket);
   }
@@ -104,9 +108,13 @@ function processSendPacketResponse(packetResponse: any[]): Packet[] {
       sendTx: sendPacket.transactionHash,
       rcvTx: sendPacket.packetRelation?.recvPacket?.transactionHash,
       ackTx: sendPacket.packetRelation?.ackPacket?.transactionHash,
-      sourceClient: sendPacket.sourceChannel?.portId.split('.')[1],
-      destClient: sendPacket.sourceChannel?.counterpartyPortId.split('.')[1],
-      senderAddress: sendPacket.uchEventSender || sendPacket.packetDataSender || ''
+      sourceClient: sendPacket.sourceChannel?.portId.split('.')[1] || '',
+      destClient: sendPacket.sourceChannel?.counterpartyPortId.split('.')[1] || '',
+      senderAddress: sendPacket.uchEventSender || sendPacket.packetDataSender || '',
+      totalRecvFeesDeposited: sendPacket.totalRecvFeesDeposited || 0,
+      recvGasLimit: sendPacket.firstFeeDeposited?.recvGasLimit || undefined,
+      totalAckFeesDeposited: sendPacket.totalAckFeesDeposited || 0,
+      ackGasLimit: sendPacket.firstFeeDeposited?.ackGasLimit || undefined
     };
     packets.push(newPacket);
   }
@@ -127,6 +135,12 @@ export function generatePacketQuery(params?: string): { query: string } {
           transactionHash
           packetDataSender
           uchEventSender
+          totalRecvFeesDeposited
+          totalAckFeesDeposited
+          firstFeeDeposited {
+            recvGasLimit
+            ackGasLimit
+          }
           sourceChannel {
             channelId
             counterpartyChannelId
@@ -167,6 +181,12 @@ export function generateSendPacketQuery(params?: string): { query: string } {
         transactionHash
         packetDataSender
         uchEventSender
+        totalRecvFeesDeposited
+        totalAckFeesDeposited
+        firstFeeDeposited {
+          recvGasLimit
+          ackGasLimit
+        }
         sourceChannel {
           channelId
           counterpartyChannelId

--- a/app/utils/functions.tsx
+++ b/app/utils/functions.tsx
@@ -5,3 +5,7 @@ export function classNames(...classes: string[]) {
 export function classLogic(func: () => string): string {
   return func();
 }
+
+export function numberWithCommas(input: number): string {
+  return input.toLocaleString('en');
+}

--- a/app/utils/types/packet.ts
+++ b/app/utils/types/packet.ts
@@ -16,6 +16,10 @@ export interface Packet {
   sourceClient: string;
   destClient: string;
   senderAddress?: string;
+  totalRecvFeesDeposited: number;
+  recvGasLimit?: number;
+  totalAckFeesDeposited: number;
+  ackGasLimit?: number;
 }
 
 export enum PacketStates {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -17,7 +17,8 @@ const config: Config = {
         'turquoise': '#02DBC4',
         'vapor': '#F1E9f7',
         'white': '#FFFFFF',
-        'dark-gray': '#282729'
+        'dark-gray': '#282729',
+        'warning': '#F695A1'
       },
       fontFamily: {
         primary: ['var(--primary-font)'],


### PR DESCRIPTION
**To test locally:
Set graphql env to staging:**
INDEXER_URL=https://index.stg.testnet.polymer.zone/graphql
**Packet to test:**
http://localhost:3000/packets?searchValue=polyibc.optimism-staging.109eBA765961c17159882F1a4194CA16615600B6-channel-716-27

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced `PacketDetails` component with real-time updates on transaction funding status.
  - New utility function for formatting numbers with commas for improved readability.
  - Expanded `Packet` interface to include additional fields for better tracking of transaction fees and gas limits.

- **Bug Fixes**
  - Improved packet processing logic to ensure comprehensive data handling with new properties.

- **Chores**
  - Added a new warning color to the Tailwind CSS configuration for better styling options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->